### PR TITLE
Add delete_all_occurrences_by_item_id method

### DIFF
--- a/rollbar_client.rb
+++ b/rollbar_client.rb
@@ -31,4 +31,13 @@ class RollbarClient
       raise result['message']
     end
   end
+
+  def delete_all_occurrences_by_item_id(item_id)
+    count = 0
+    while occurrences = get_occurrences_by_item_id(item_id).presence
+      occurrences.each {|occ| delete_occurrence(occ['id']) }
+      count += occurrences.count
+    end
+    puts "#{count} occurrences have been deleted."
+  end
 end


### PR DESCRIPTION
I've added `delete_all_occurrences_by_item_id` to remove all occurrences for given item.
The ` /api/1/item/{item_id}/instances` GET endpoint only returns 20 items at the time. If there are many items, removing them step by step can be tedious.

https://explorer.docs.rollbar.com/#tag/Occurrence/paths/~1api~11~1item~1{item_id}~1instances/get